### PR TITLE
Fix kubectl rune args

### DIFF
--- a/rune-definitions.yaml
+++ b/rune-definitions.yaml
@@ -38,7 +38,7 @@ KubectlRune:
     Image: '{{ or .image "sygaldry/kubectl-rune"}}:{{or .version "latest" }}'
     Env:
     - command="{{ .command }}"
-    - args="{ .args }}"
+    - args="{{ .args }}"
     Volumes:
     - '{{ or .kubeConfigPath "~/.kube/config"}}:/root/.kube/config'
 NpmRune:


### PR DESCRIPTION
I was missing a { in the template var